### PR TITLE
Add cloudinit resource support

### DIFF
--- a/lib/fog/brkt/compute.rb
+++ b/lib/fog/brkt/compute.rb
@@ -7,6 +7,14 @@ require "fog/brkt/core"
 
 module Fog
   module Compute
+    module State
+      READY = "READY"
+      FAILED = "FAILED"
+      POWERING_OFF = "POWERING_OFF"
+      POWERED_OFF = "POWERED_OFF"
+      TERMINATING = "TERMINATING"
+      TERMINATED = "TERMINATED"
+    end
     class Brkt < Fog::Service
 
       requires :brkt_public_access_token, :brkt_private_mac_key, :brkt_api_host
@@ -29,6 +37,8 @@ module Fog
       collection :images
       model      :csp_image
       collection :csp_images
+      model      :cloudinit
+      collection :cloudinits
       model      :workload_template
       collection :workload_templates
       model      :workload
@@ -100,6 +110,11 @@ module Fog
       request :create_csp_image
       request :delete_csp_image
       request :list_image_csp_images
+      request :create_cloudinit
+      request :get_cloudinit
+      request :delete_cloudinit
+      request :list_cloudinits
+      request :update_cloudinit
       request :create_volume_template
       request :delete_volume_template
       request :list_volume_templates
@@ -131,6 +146,7 @@ module Fog
       request :update_load_balancer
       request :get_load_balancer
       request :list_load_balancers
+      request :list_workload_load_balancers
       request :create_load_balancer_template_listener
       request :delete_load_balancer_template_listener
       request :list_load_balancer_template_listeners
@@ -224,6 +240,7 @@ module Fog
             },
             :computing_cells         => {},
             :billing_groups          => {},
+            :cloudinits              => {},
             :workload_templates      => {},
             :workloads               => {},
             :server_templates        => {},

--- a/lib/fog/brkt/models/compute/billing_group.rb
+++ b/lib/fog/brkt/models/compute/billing_group.rb
@@ -10,17 +10,16 @@ module Fog
         attribute :name
         attribute :description
         attribute :members, :type => :array
-        attribute :customer, :aliases => [:customer_id]
         # @!endgroup
 
         # Create billing group.
-        # Required attributes: *name*, *customer*
+        # Required attributes: *name*
         #
         # @return [true]
         def save
-          requires :name, :customer
+          requires :name
 
-          data = service.create_billing_group(customer, name, {
+          data = service.create_billing_group(name, {
             :description => description,
             :members     => members
           }).body

--- a/lib/fog/brkt/models/compute/cloudinit.rb
+++ b/lib/fog/brkt/models/compute/cloudinit.rb
@@ -1,0 +1,79 @@
+require "fog/core/model"
+
+module Fog
+  module Compute
+    class Brkt
+      class Cloudinit < Fog::Model
+        module Platform
+          LINUX = "LINUX"
+          WINDOWS = "WINDOWS"
+        end
+        module DeploymentType
+          DEFAULT = "DEFAULT"
+          CONFIGURED = "CONFIGURED"
+          ADVANCED = "ADVANCED"
+        end
+        # @!group Attributes
+        identity :id
+
+        attribute :customer
+        attribute :name
+        attribute :description
+        attribute :platform,        :default => Platform::LINUX
+        attribute :deployment_type, :default => DeploymentType::DEFAULT
+        attribute :cloud_config
+        attribute :user_script
+        attribute :user_data
+        attribute :metadata
+        # @!endgroup
+
+        def deployment_type
+          if platform == Platform::WINDOWS
+            case attributes[:deployment_type]
+            when "EC2_DEFAULT"
+              return DeploymentType::DEFAULT
+            when "EC2_CONFIGURED"
+              return DeploymentType::CONFIGURED
+            when "EC2_ADVANCED"
+              return DeploymentType::ADVANCED
+            end
+          end
+          return attributes[:deployment_type]
+        end
+
+        def initialize(attributes={})
+          case attributes[:deployment_type]
+          when "EC2_DEFAULT", "EC2_CONFIGURED", "EC2_ADVANCED"
+            self.platform = Platform::WINDOWS
+          else
+            self.platform = Platform::LINUX
+          end
+          super
+        end
+
+        # Create cloud init
+        # Required attributes: *name*, *platform*, *deployment_type*
+        #
+        #
+        # @return [true]
+        def save
+          requires :name, :platform, :deployment_type
+
+          data = service.create_cloudinit(attributes).body
+          merge_attributes(data)
+          true
+        end
+
+        # Delete cloud init
+        #
+        # @return [true]
+        def destroy
+          requires :id
+
+          service.delete_cloudinit(id)
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brkt/models/compute/cloudinits.rb
+++ b/lib/fog/brkt/models/compute/cloudinits.rb
@@ -1,0 +1,27 @@
+require "fog/core/collection"
+require "fog/brkt/models/compute/cloudinit"
+
+module Fog
+  module Compute
+    class Brkt
+      class Cloudinits < Fog::Collection
+        model Fog::Compute::Brkt::Cloudinit
+
+        # Get cloud inits
+        #
+        # @return [Array<CloudInit>] cloud inits
+        def all
+          load(service.list_cloudinits.body)
+        end
+
+        # Get cloud init by ID
+        #
+        # @param [String] id cloud init id
+        # @return [CloudInit] cloud init
+        def get(id)
+          new(service.get_cloudinit(id).body)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brkt/models/compute/computing_cell.rb
+++ b/lib/fog/brkt/models/compute/computing_cell.rb
@@ -71,14 +71,25 @@ module Fog
           end
         end
 
-        # Returns true if API responds with 404
-        def completely_deleted?
-          begin
-            reload
-            false
-          rescue Excon::Errors::NotFound
-            true
-          end
+        # @return [String]
+        def state
+          provider_options["state"]
+        end
+
+        def ready?
+          state == Compute::State::READY
+        end
+
+        def failed?
+          state == Compute::State::FAILED
+        end
+
+        def terminating?
+          state == Compute::State::TERMINATING
+        end
+
+        def terminated?
+          state == Compute::State::TERMINATED
         end
       end
     end

--- a/lib/fog/brkt/models/compute/load_balancer.rb
+++ b/lib/fog/brkt/models/compute/load_balancer.rb
@@ -55,6 +55,35 @@ module Fog
           true
         end
 
+        # @return [String]
+        def state
+          provider_load_balancer["state"]
+        end
+
+        def ready?
+          state == Compute::State::READY
+        end
+
+        def failed?
+          state == Compute::State::FAILED
+        end
+
+        def powering_off?
+          state == Compute::State::POWERING_OFF
+        end
+
+        def powered_off?
+          state == Compute::State::POWERED_OFF
+        end
+
+        def terminating?
+          state == Compute::State::TERMINATING
+        end
+
+        def terminated?
+          state == Compute::State::TERMINATED
+        end
+
         # Get load balancer listeners associated with load balancer
         #
         # @return [LoadBalancerListeners] load balancer listeners collection

--- a/lib/fog/brkt/models/compute/load_balancer_listeners.rb
+++ b/lib/fog/brkt/models/compute/load_balancer_listeners.rb
@@ -18,6 +18,18 @@ module Fog
           requires :load_balancer
           load(service.list_load_balancer_listeners(load_balancer.id).body)
         end
+
+        # Create a new instance of a load balancer listener
+        # If {#load_balancer} attribute is set, sets
+        # {LoadBalancerListener#load_balancer} attribute
+        # to a {#load_balancer}'s id
+        #
+        # @param [Hash] attributes load balancer listener attributes
+        # @return [LoadBalancerListener] LoadBalancerListener instance
+        def new(attributes={})
+          requires :load_balancer
+          super({:load_balancer => load_balancer.id}.merge(attributes))
+        end
       end
     end
   end

--- a/lib/fog/brkt/models/compute/load_balancer_template_listeners.rb
+++ b/lib/fog/brkt/models/compute/load_balancer_template_listeners.rb
@@ -18,6 +18,18 @@ module Fog
           requires :load_balancer_template
           load(service.list_load_balancer_template_listeners(load_balancer_template.id).body)
         end
+
+        # Create a new instance of a load balancer template listener
+        # If {#load_balancer_template} attribute is set, sets
+        # {LoadBalancerTemplateListener#load_balancer_template} attribute
+        # to a {#load_balancer_template}'s id
+        #
+        # @param [Hash] attributes load balancer template listener attributes
+        # @return [LoadBalancerTemplateListener] LoadBalancerTemplateListener instance
+        def new(attributes={})
+          requires :load_balancer_template
+          super({:load_balancer_template => load_balancer_template.id}.merge(attributes))
+        end
       end
     end
   end

--- a/lib/fog/brkt/models/compute/load_balancers.rb
+++ b/lib/fog/brkt/models/compute/load_balancers.rb
@@ -7,11 +7,27 @@ module Fog
       class LoadBalancers < Fog::Collection
         model Fog::Compute::Brkt::LoadBalancer
 
+        # @return [Workload]
+        attr_accessor :workload
+
         # Get load balancers.
         #
         # @return [Array<LoadBalancer>] load balancers
         def all
           load(service.list_load_balancers.body)
+        end
+
+        # Get load balancers.
+        # If {#workload} attribute is set, returns only load balancers
+        # scoped by workload and returns all load balancers otherwise
+        #
+        # @return [Array<LoadBalancer>] load balancers
+        def all(filter={})
+          if workload.nil?
+            load(service.list_load_balancers(filter).body)
+          else
+            load(service.list_workload_servers(workload.id).body)
+          end
         end
 
         # Get load balancer by ID
@@ -20,6 +36,18 @@ module Fog
         # @return [LoadBalancer] load balancer
         def get(id)
           new(service.get_load_balancer(id).body)
+        end
+
+        # Create a new instance of load balancer.
+        # If {#workload} attribute is set, sets {LoadBalancer#workload}
+        # attribute to an {#workload_template}'s id
+        #
+        # @param [Hash] attributes load balancer attributes
+        # @return [LoadBalancer] load balancer instance
+        def new(attributes={})
+          instance = super
+          instance.workload = workload.id unless workload.nil?
+          instance
         end
       end
     end

--- a/lib/fog/brkt/models/compute/server.rb
+++ b/lib/fog/brkt/models/compute/server.rb
@@ -4,15 +4,6 @@ module Fog
   module Compute
     class Brkt
       class Server < Fog::Compute::Server
-        module State
-          READY = "READY"
-          FAILED = "FAILED"
-          POWERING_OFF = "POWERING_OFF"
-          POWERED_OFF = "POWERED_OFF"
-          TERMINATING = "TERMINATING"
-          TERMINATED = "TERMINATED"
-        end
-
         # @!group Attributes
         identity :id
 
@@ -30,6 +21,7 @@ module Fog
         attribute :load_balancer
         attribute :service_name
         attribute :service_name_fqdn
+        attribute :cloudinit
         attribute :metadata
         # @!endgroup
 
@@ -37,6 +29,7 @@ module Fog
         has_one_identity :image_definition, :images
         has_one_identity :machine_type, :machine_types
         has_one_identity :load_balancer, :load_balancers
+        has_one_identity :cloudinit, :cloudinits
 
         def initialize(options={})
           self.metadata = {}
@@ -50,27 +43,27 @@ module Fog
         end
 
         def ready?
-          state == State::READY
+          state == Compute::State::READY
         end
 
         def failed?
-          state == State::FAILED
+          state == Compute::State::FAILED
         end
 
         def powering_off?
-          state == State::POWERING_OFF
+          state == Compute::State::POWERING_OFF
         end
 
         def powered_off?
-          state == State::POWERED_OFF
+          state == Compute::State::POWERED_OFF
         end
 
         def terminating?
-          state == State::TERMINATING
+          state == Compute::State::TERMINATING
         end
 
         def terminated?
-          state == State::TERMINATED
+          state == Compute::State::TERMINATED
         end
 
         def internet_accessible?
@@ -89,6 +82,7 @@ module Fog
           else
             requires :name, :image_definition, :machine_type, :workload
 
+            attributes[:cloudinit] = associations[:cloudinit]
             data = service.create_server(
               associations[:image_definition],
               associations[:machine_type],

--- a/lib/fog/brkt/models/compute/server_template.rb
+++ b/lib/fog/brkt/models/compute/server_template.rb
@@ -28,13 +28,15 @@ module Fog
         attribute :hourly_cost, :type => :float
         attribute :daily_cost, :type => :float
         attribute :monthly_cost, :type => :float
-        attribute :cloudinit_id
-        attribute :cloudinit_script
-        attribute :cloudinit_type
-        attribute :internet_accessible, :type => :boolean
+        attribute :cloudinit_id, :aliases => ["cloudinit", :cloudinit]
         attribute :state
         attribute :metadata
         # @!endgroup
+
+        has_one_identity :workload_template, :workload_templates
+        has_one_identity :load_balancer_template, :load_balancer_templates
+        has_one_identity :machine_type, :machine_types
+        has_one_identity :cloudinit_id, :cloudinits
 
         # Create or update server template.
         # Required attributes for create: {#name}, {#image_definition}, {#workload_template}
@@ -48,7 +50,12 @@ module Fog
 
             attrs = attributes.dup
             attrs.delete(:workload_template)
-            data = service.create_server_template(workload_template, attrs).body
+            attrs[:machine_type] = associations[:machine_type]
+            attrs[:load_balancer_template] = associations[:load_balancer_template]
+            attrs[:cloudinit_id] = associations[:cloudinit_id]
+            data = service.create_server_template(
+              associations[:workload_template],
+              attrs).body
           end
 
           merge_attributes(data)
@@ -70,10 +77,6 @@ module Fog
 
         def requires_gpu?
           !!requires_gpu
-        end
-
-        def internet_accessible?
-          !!internet_accessible
         end
 
         # Get volume templates attached to a server template

--- a/lib/fog/brkt/models/compute/volume.rb
+++ b/lib/fog/brkt/models/compute/volume.rb
@@ -4,9 +4,6 @@ module Fog
   module Compute
     class Brkt
       class Volume < Fog::Model
-        module State
-          READY = "READY"
-        end
 
         # @!group Attributes
         identity :id
@@ -58,8 +55,33 @@ module Fog
           true
         end
 
+        # @return [String]
+        def state
+          provider_bracket_volume["state"]
+        end
+
         def ready?
-          provider_bracket_volume["state"] == State::READY
+          state == Compute::State::READY
+        end
+
+        def failed?
+          state == Compute::State::FAILED
+        end
+
+        def powering_off?
+          state == Compute::State::POWERING_OFF
+        end
+
+        def powered_off?
+          state == Compute::State::POWERED_OFF
+        end
+
+        def terminating?
+          state == Compute::State::TERMINATING
+        end
+
+        def terminated?
+          state == Compute::State::TERMINATED
         end
 
         # Create volume snapshot

--- a/lib/fog/brkt/requests/compute/create_billing_group.rb
+++ b/lib/fog/brkt/requests/compute/create_billing_group.rb
@@ -2,13 +2,13 @@ module Fog
   module Compute
     class Brkt
       class Real
-        def create_billing_group(customer_id, name, options = {})
+        def create_billing_group(name, options = {})
           request(
             :expects => [201],
             :method  => 'POST',
             :path    => 'v1/api/config/billinggroup/',
             :body    => Fog::JSON.encode({
-              :customer    => customer_id,
+              :customer    => customer.id,
               :name        => name,
               :description => options[:description],
               :members     => options[:members]
@@ -18,11 +18,11 @@ module Fog
       end
 
       class Mock
-        def create_billing_group(customer_id, name, options = {})
+        def create_billing_group(name, options = {})
           response = Excon::Response.new
           id = Fog::Brkt::Mock.id
           data = {
-            'customer'          => customer_id,
+            'customer'          => customer.id,
             'spent_cost'        => '0.00',
             'modified_by'       => 'admin@brkt.com',
             'name'              => name,

--- a/lib/fog/brkt/requests/compute/create_cloudinit.rb
+++ b/lib/fog/brkt/requests/compute/create_cloudinit.rb
@@ -1,0 +1,52 @@
+module Fog
+  module Compute
+    class Brkt
+      class Real
+        def create_cloudinit(options = {})
+          metadata = options[:metadata] ? options[:metadata] : {}
+          request(
+            :expects => [201],
+            :method  => 'POST',
+            :path    => "v1/api/config/cloudinit",
+            :body    => Fog::JSON.encode({
+              :name            => options[:name],
+              :customer        => customer.id,
+              :id              => options[:id],
+              :description     => options[:description],
+              :deployment_type => options[:deployment_type],
+              :cloud_config    => options[:cloud_config],
+              :user_config     => options[:user_config],
+              :user_script     => options[:user_script],
+              :metadata        => metadata
+            })
+          )
+        end
+      end
+
+      class Mock
+        def create_cloudinit(options = {})
+          response = Excon::Response.new
+          id = Fog::Brkt::Mock.id
+          data = {
+            'id'                => id,
+            'customer'          => Fog::Brkt::Mock.id,
+            'name'              => options[:name],
+            'description'       => options[:description],
+            'created_by'        => 'admin@brkt.com',
+            'modified_by'       => 'admin@brkt.com',
+            'created_time'      => '2015-01-26T22:30:00.225941+00:00',
+            'modified_time'     => '2015-01-26T22:30:00.242419+00:00',
+            'metadata'          => {'role' => 'dev'},
+            'deployment_type'   => 'CONFIGURED',
+            'cloud_config'      => 'groups:\n  - ubuntu: [foo,bar]\n  - cloud-users',
+            'user_script'       => nil,
+            'user_data'         => nil
+          }
+          self.data[:cloudinits][id] = data
+          response.body = data
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brkt/requests/compute/create_computing_cell.rb
+++ b/lib/fog/brkt/requests/compute/create_computing_cell.rb
@@ -39,7 +39,7 @@ module Fog
             "metadata"                => {},
             "provider_computing_cell" => {
               "default_aws_avail_zone" => "us-west-2b",
-              "state"                  => "IGNORE",
+              "state"                  => "READY",
               "aws_region"             => "us-west-2",
               "why"                    => ""
             },
@@ -58,7 +58,7 @@ module Fog
               "cidr_block"       => cidr_block,
               "metadata"         => {},
               "provider_network" => {
-                "state" => "IGNORE",
+                "state" => "READY",
                 "why"   => ""
               }
             }

--- a/lib/fog/brkt/requests/compute/create_server.rb
+++ b/lib/fog/brkt/requests/compute/create_server.rb
@@ -37,6 +37,7 @@ module Fog
             "modified_time"       => "2015-03-04T22:32:02.496169+00:00",
             "internet_accessible" => false,
             "machine_type"        => machine_type_id,
+            "cloudinit"           => "df43995a1d8a48d28b835238bfd079b4",
             "created_time"        => "2015-03-04T22:32:02.496133+00:00",
             "internet_ip_address" => "127.0.0.1",
             "ip_address"          => nil,

--- a/lib/fog/brkt/requests/compute/delete_cloudinit.rb
+++ b/lib/fog/brkt/requests/compute/delete_cloudinit.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Compute
+    class Brkt
+      class Real
+        def delete_cloudinit(id)
+          request(
+            :expects => [200],
+            :method  => "DELETE",
+            :path    => "v1/api/config/cloudinit/#{id}"
+          )
+        end
+      end
+
+      class Mock
+        def delete_cloudinit(id)
+          self.data[:cloudinits].delete(id)
+          Excon::Response.new
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brkt/requests/compute/delete_computing_cell.rb
+++ b/lib/fog/brkt/requests/compute/delete_computing_cell.rb
@@ -14,7 +14,8 @@ module Fog
       class Mock
         def delete_computing_cell(id)
           response = Excon::Response.new
-          self.data[:computing_cells].delete(id)
+          computing_cell = self.data[:computing_cells][id]
+          computing_cell["provider_computing_cell"]["state"] = "TERMINATED"
           response
         end
       end

--- a/lib/fog/brkt/requests/compute/get_cloudinit.rb
+++ b/lib/fog/brkt/requests/compute/get_cloudinit.rb
@@ -2,17 +2,17 @@ module Fog
   module Compute
     class Brkt
       class Real
-        def get_volume(id)
+        def get_cloudinit(id)
           request(
             :expects => [200],
-            :path    => "v1/api/config/brktvolume/#{id}?show_deleted=true"
+            :path    => "v1/api/config/cloudinit/#{id}"
           )
         end
       end
 
       class Mock
-        def get_volume(id)
-          Excon::Response.new(:body => self.data[:volumes][id])
+        def get_cloudinit(id)
+          Excon::Response.new(:body => self.data[:cloudinits][id])
         end
       end
     end

--- a/lib/fog/brkt/requests/compute/get_computing_cell.rb
+++ b/lib/fog/brkt/requests/compute/get_computing_cell.rb
@@ -5,7 +5,7 @@ module Fog
         def get_computing_cell(id)
           request(
             :expects => [200],
-            :path    => "v1/api/config/computingcell/#{id}"
+            :path    => "v1/api/config/computingcell/#{id}?show_deleted=true"
           )
         end
       end

--- a/lib/fog/brkt/requests/compute/get_load_balancer.rb
+++ b/lib/fog/brkt/requests/compute/get_load_balancer.rb
@@ -5,7 +5,7 @@ module Fog
         def get_load_balancer(id)
           request(
             :expects => [200],
-            :path    => "v1/api/config/loadbalancer/#{id}"
+            :path    => "v1/api/config/loadbalancer/#{id}?show_deleted=true"
           )
         end
       end

--- a/lib/fog/brkt/requests/compute/get_security_group.rb
+++ b/lib/fog/brkt/requests/compute/get_security_group.rb
@@ -5,7 +5,7 @@ module Fog
         def get_security_group(id)
           request(
             :expects => [200],
-            :path    => "v1/api/config/securitygroup/#{id}"
+            :path    => "v1/api/config/securitygroup/#{id}?show_deleted=true"
           )
         end
       end

--- a/lib/fog/brkt/requests/compute/get_server.rb
+++ b/lib/fog/brkt/requests/compute/get_server.rb
@@ -5,7 +5,7 @@ module Fog
         def get_server(id)
           request(
             :expects => [200],
-            :path    => "v2/api/config/instance/#{id}"
+            :path    => "v2/api/config/instance/#{id}?show_deleted=true"
           )
         end
       end

--- a/lib/fog/brkt/requests/compute/list_cloudinits.rb
+++ b/lib/fog/brkt/requests/compute/list_cloudinits.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Compute
+    class Brkt
+      class Real
+        def list_cloudinits
+          request(
+            :expects => [200],
+            :path    => "v1/api/config/cloudinit"
+          )
+        end
+      end
+
+      class Mock
+        def list_cloudinits
+          Excon::Response.new(:body => self.data[:cloudinits].map { |id, cloudinit| cloudinit })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brkt/requests/compute/list_load_balancers.rb
+++ b/lib/fog/brkt/requests/compute/list_load_balancers.rb
@@ -2,16 +2,17 @@ module Fog
   module Compute
     class Brkt
       class Real
-        def list_load_balancers
+        def list_load_balancers(filter={})
           request(
             :expects => [200],
-            :path    => "v1/api/config/loadbalancer"
+            :path    => "v1/api/config/loadbalancer",
+            :query   => filter
           )
         end
       end
 
       class Mock
-        def list_load_balancers
+        def list_load_balancers(filter={})
           response = Excon::Response.new
           response.body = self.data[:load_balancers].map { |id, lb_data| lb_data }
           response

--- a/lib/fog/brkt/requests/compute/list_workload_load_balancers.rb
+++ b/lib/fog/brkt/requests/compute/list_workload_load_balancers.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Compute
+    class Brkt
+      class Real
+        def list_workload_load_balancers(workload_id, filter = {})
+          filter[:workload] = workload_id
+          request(
+            :expects => [200],
+            :path    => "v2/api/config/loadbalancer",
+            :query   => filter
+          )
+        end
+      end
+
+      class Mock
+        def list_workload_load_balancers(workload_id, filter = {})
+          response = Excon::Response.new
+          data = self.data[:load_balancers].select do |lb_id, lb_data|
+            lb_data["workload"] == workload_id
+          end.map { |lb_id, lb_data| lb_data }
+          response.body = data
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brkt/requests/compute/update_cloudinit.rb
+++ b/lib/fog/brkt/requests/compute/update_cloudinit.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Compute
+    class Brkt
+      class Real
+        def update_cloudinit(id, options={})
+          request(
+            :expects => [202],
+            :method  => "POST",
+            :path    => "v2/api/config/cloudinit/#{id}",
+            :body    => Fog::JSON.encode(options)
+          )
+        end
+      end
+
+      class Mock
+        def update_cloudinit(id, options={})
+          response = Excon::Response.new
+          cloudinit = self.data[:cloudinits][id]
+          cloudinit.merge!(Fog::StringifyKeys.stringify(options))
+          response.body = cloudinit
+          response
+        end
+      end
+    end
+  end
+end

--- a/spec/models/compute/cloudinit_spec.rb
+++ b/spec/models/compute/cloudinit_spec.rb
@@ -1,0 +1,2 @@
+describe Fog::Compute::Brkt::Cloudinit do
+end

--- a/spec/models/compute/cloudinit_specs.rb
+++ b/spec/models/compute/cloudinit_specs.rb
@@ -1,0 +1,2 @@
+describe Fog::Compute::Brkt::Cloudinits do
+end

--- a/spec/requests/compute/billing_group_spec.rb
+++ b/spec/requests/compute/billing_group_spec.rb
@@ -24,7 +24,7 @@ describe "billing group requests" do
   describe "#create_billing_group" do
     before(:all) do
       @group_name = Fog::Brkt::Mock.name
-      @response = compute.create_billing_group(compute.customer.id, @group_name, {
+      @response = compute.create_billing_group(@group_name, {
         description: "description",
         members:     ["user@example.com"]
       })
@@ -48,7 +48,6 @@ describe "billing group requests" do
   describe "#list_billing_groups" do
     before(:all) do
       @billing_group = compute.billing_groups.create(
-        :customer_id => compute.customer.id,
         :name        => Fog::Brkt::Mock.name
       )
       @response = compute.list_billing_groups

--- a/spec/requests/compute/cloudinit_spec.rb
+++ b/spec/requests/compute/cloudinit_spec.rb
@@ -1,0 +1,90 @@
+describe "cloudinit requests" do
+  let(:cloudinit_format) do
+    {
+      "id"                  => String,
+      "customer"            => String,
+      "name"                => String,
+      "description"         => Fog::Nullable::String,
+      "deployment_type"     => String,
+      "user_script"         => Fog::Nullable::String,
+      "cloud_config"        => Fog::Nullable::String,
+      "user_data"           => Fog::Nullable::String,
+      "created_by"          => String,
+      "modified_by"         => String,
+      "created_time"        => String,
+      "modified_time"       => String,
+      "metadata"            => Hash
+    }
+  end
+
+  describe "#create_cloudinit" do
+    before(:all) do
+      @cloudinit_name = Fog::Brkt::Mock.name
+      @response = compute.create_cloudinit(
+        :name => @cloudinit_name,
+        :description => "description")
+    end
+
+    after(:all) { compute.delete_cloudinit(@response.body["id"]) }
+
+    describe "response" do
+      subject { @response.body }
+
+      it { is_expected.to have_format(cloudinit_format) }
+      it { expect(subject["id"]).to_not be_nil }
+      it { expect(subject["name"]).to eq @cloudinit_name }
+    end
+  end
+
+  describe "#update_cloudinit" do
+    before(:all) do
+      @cloudinit = compute.cloudinits.create({
+        :name            => Fog::Brkt::Mock.name,
+        :deployment_type => "DEFAULT"
+      })
+      @response = compute.update_cloudinit(@cloudinit.id, { :name => "new name"} )
+    end
+
+    after(:all) { @cloudinit.destroy }
+
+    describe "response" do
+      subject { @response.body }
+
+      it { is_expected.to have_format(cloudinit_format) }
+      it { expect(subject["name"]).to eq "new name" }
+    end
+  end
+
+  describe "#list_cloudinits" do
+    before(:all) {
+      compute.create_cloudinit(
+        :name => Fog::Brkt::Mock.name,
+        :description => "description")
+      @response = compute.list_cloudinits
+    }
+
+    describe "response" do
+      subject { @response.body }
+
+      it { is_expected.to have_format([cloudinit_format]) }
+    end
+  end
+
+  describe "#get_cloudinit" do
+    before(:all) do
+      @cloudinit = compute.cloudinits.create({
+        :name            => "hello",
+        :deployment_type => "DEFAULT"
+      })
+      @response = compute.get_cloudinit(@cloudinit.id)
+    end
+
+    after(:all) { @cloudinit.destroy }
+
+    describe "response" do
+      subject { @response.body }
+
+      it { is_expected.to have_format(cloudinit_format) }
+    end
+  end
+end

--- a/spec/requests/compute/computing_cell_spec.rb
+++ b/spec/requests/compute/computing_cell_spec.rb
@@ -47,14 +47,6 @@ describe "computing cell requests" do
     after(:all) do
       id = @response.body["id"]
       compute.delete_computing_cell(id)
-      Fog.wait_for do
-        begin
-          compute.get_computing_cell(id)
-          false
-        rescue
-          true
-        end
-      end
     end
 
     describe "response" do

--- a/spec/requests/compute/load_balancer_listener_spec.rb
+++ b/spec/requests/compute/load_balancer_listener_spec.rb
@@ -72,8 +72,7 @@ describe "load balancer listener requests" do
 
   describe "#list_load_balancer_listeners" do
     before(:all) do
-      compute.load_balancer_listeners.create({
-        :load_balancer            => @lb.id,
+      @lb.listeners.create({
         :instance_protocol        => "HTTP",
         :instance_port            => 80,
         :listener_protocol        => "HTTP",

--- a/spec/requests/compute/zone_spec.rb
+++ b/spec/requests/compute/zone_spec.rb
@@ -29,7 +29,7 @@ describe "network zone requests" do
     @cell.destroy
     # wait while computing cell will be deleted completely and API will return 404
     # to prevent hitting the limit
-    Fog.wait_for { @cell.completely_deleted? }
+    Fog.wait_for { @cell.terminated? }
   end
 
   describe "#create_zone" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,12 +35,17 @@ def delete_computing_cell(cell)
   cell.destroy
   # wait while computing cell will be deleted completely and API will return 404
   # to prevent hitting the limit
-  Fog.wait_for { cell.completely_deleted? }
+  Fog.wait_for { cell.terminated? }
 end
 
 def fast_tests?
   ENV["FAST_TESTS"] == "true" || ENV["FAST_TESTS"] == "1"
 end
 
-RSpec.configure do |c|
+RSpec.configure do |config|
+  # Use color not only in STDOUT but also in pagers and files
+  config.tty = true
+
+  # Use the specified formatter
+  config.formatter = :documentation
 end


### PR DESCRIPTION
This change adds cloudinit models, and attributes into related
models.  This allows the user to manage cloudinit configurations
independently, and assign them to either server or server template
models.  This change also includes a fair amount of cleanup:

- state is now accessible for most models
- wait_for {ready?} and wait_for {terminated?} is supported for most
  models
- load balancers can now be created and managed without templates