### PR TITLE
Removed credentials cection from compute call

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ These Ruby files all have the .rb file extension. To run any of these Ruby scrip
 
 Alternatively, these example scripts have been configured to run without using the Ruby command. The shebang line is already done for you; it's the first line in the script starting with #!. This tells the shell what type of file this is. In this case it's a Ruby file to be executed with the Ruby interpreter. To mark the file as executable, run the command chmod +x {scriptname}.rb. This will set a file permission bit indicating that the file is a program and that it can be run. Now, to run the program simply enter the command ./{scriptname}.rb.
 
-<b>Since it's a bad practice to have your credentials in source code, you should load them from the default fog configuration file: ~/.fog. This file could look like this:<b>
+<b>Since it's a bad practice to have your credentials in source code, you should load them from the default fog configuration file: ~/.fog. This file could look like this:</b>
 
 ```
 default:

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,11 +18,13 @@ These Ruby files all have the .rb file extension. To run any of these Ruby scrip
 
 Alternatively, these example scripts have been configured to run without using the Ruby command. The shebang line is already done for you; it's the first line in the script starting with #!. This tells the shell what type of file this is. In this case it's a Ruby file to be executed with the Ruby interpreter. To mark the file as executable, run the command chmod +x {scriptname}.rb. This will set a file permission bit indicating that the file is a program and that it can be run. Now, to run the program simply enter the command ./{scriptname}.rb.
 
-Since it's a bad practice to have your credentials in source code, you should load them from the default fog configuration file: ~/.fog. This file could look like this:
+<b>Since it's a bad practice to have your credentials in source code, you should load them from the default fog configuration file: ~/.fog. This file could look like this:<b>
 
+```
 default:
   brkt_public_access_token: <YOUR_ACCESS_TOKEN>
   brkt_private_mac_key: <YOUR_SECRET_MAC_KEY>
+```
 
 If there is no .fog file in your home directory, simply create one.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,11 +4,11 @@
 
 ![fog](http://geemus.s3.amazonaws.com/fog.png)
 
-fog is the Ruby cloud services library, top to bottom:
+fog is the Ruby cloud services library, top to bottom:<sup>[!](#fogfootnote)</sup>
 
-* Collections provide a simplified interface, making clouds easier to work with and switch between.<sup>[1](#myfootnote1)</sup>
-* Requests allow power users to get the most out of the features of each individual cloud.
-* Mocks make testing and integrating a breeze.
+* Collections provide a simplified interface, making clouds easier to work with and switch between.<sup>[!](#fogfootnote)</sup>
+* Requests allow power users to get the most out of the features of each individual cloud.<sup>[!](#fogfootnote)</sup>
+* Mocks make testing and integrating a breeze.<sup>[!](#fogfootnote)</sup>
 
 The following folder contains a collection of examples of using the Fog::Brkt module in Ruby scripts. Use these examples as your guide to integrate Fog::Ruby into your Bracket projects! For  description of the module please see: https://github.com/brkt/fog-brkt-ruby 
 
@@ -65,4 +65,4 @@ created by Andy Ryan based on original work done by Berndt Jung<br>
 andy@brkt.com<br>
 date: 6/15/15
 
-<a name="myfootnote1">1</a>: Footnote content goes here
+<a name="fogfootnote"><i>!</a>: This text was copied directly from the Fog github README page which can be found here: https://github.com/fog/fog</i>

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,4 +65,4 @@ created by Andy Ryan based on original work done by Berndt Jung<br>
 andy@brkt.com<br>
 date: 6/15/15
 
-<a name="fogfootnote"><i>!</a>: This text was copied directly from the Fog github README page which can be found here: https://github.com/fog/fog</i>
+<a name="fogfootnote">*!</a>: This text was copied directly from the Fog github README page which can be found here: https://github.com/fog/fog*

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ The following folder contains a collection of examples of using the Fog::Brkt mo
 
 ## Usage
 
-These Ruby files all have the .rb file extension. To run any of these Ruby script, run the command ruby {scriptname}.rb. 
+These Ruby files all have the .rb file extension. To run any of these Ruby scripts, run the command ruby {scriptname}.rb. 
 
 Alternatively, these example scripts have been configured to run without using the Ruby command. The shebang line is already done for you; it's the first line in the script starting with #!. This tells the shell what type of file this is. In this case it's a Ruby file to be executed with the Ruby interpreter. To mark the file as executable, run the command chmod +x {scriptname}.rb. This will set a file permission bit indicating that the file is a program and that it can be run. Now, to run the program simply enter the command ./{scriptname}.rb.
 
@@ -26,7 +26,7 @@ default:
   brkt_private_mac_key: <YOUR_SECRET_MAC_KEY>
 ```
 
-If there is no .fog file in your home directory, simply create one.
+If there is no .fog file in your home directory, simply create one. For more information, please see: http://fog.io/about/getting_started.html
 
 Note: All examples require a proper Bracket portal url. You will need to edit the following code block in each of these examples, and add in the proper url of your portal.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,7 @@
 # Fog::Brkt Examples
 
+[![Fog::Brkt VERSION](https://img.shields.io/badge/Fog%3A%3ABrkt%20Version-.9-green.svg)](https://github.com/brkt/fog-brkt-ruby)
+
 The following folder contains a collection of examples of using the Fog::Brkt module in Ruby scripts. Use these examples as your guide to integrate Fog::Ruby into your Bracket projects! For  description of the module please see: https://github.com/brkt/fog-brkt-ruby 
 
 Note: All examples require a proper Bracket portal url, along with a proper API Token and Private Key. You will need to edit the following code block in each of these examples, and add in user specific data.

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,4 +65,4 @@ created by Andy Ryan based on original work done by Berndt Jung<br>
 andy@brkt.com<br>
 date: 6/15/15
 
-<a name="fogfootnote">*!</a>: This text was copied directly from the Fog github README page which can be found here: https://github.com/fog/fog*
+<sub><a name="fogfootnote">*!</a>: This text was copied directly from the Fog github README page which can be found here: https://github.com/fog/fog*</sub>

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@
 
 fog is the Ruby cloud services library, top to bottom:
 
-* Collections provide a simplified interface, making clouds easier to work with and switch between.
+* Collections provide a simplified interface, making clouds easier to work with and switch between.<sup>[1](#myfootnote1)</sup>
 * Requests allow power users to get the most out of the features of each individual cloud.
 * Mocks make testing and integrating a breeze.
 
@@ -64,3 +64,5 @@ Fog::Brkt is a module for the 'fog' gem to support Bracket Computing Cells.
 created by Andy Ryan based on original work done by Berndt Jung<br>
 andy@brkt.com<br>
 date: 6/15/15
+
+<a name="myfootnote1">1</a>: Footnote content goes here

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,8 @@ compute = Fog::Compute.new({
 ##########################################################
 
 ```
+As an alternative, you could add the ```brkt_api_host:``` line to the .fog file shown above.
+
 
 ## Contributing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Fog::Brkt Examples
 
-[![Fog::Brkt VERSION](https://img.shields.io/badge/Fog%3A%3ABrkt%20Version-.9-green.svg)](https://github.com/brkt/fog-brkt-ruby)
+[![Fog::Brkt VERSION](https://img.shields.io/badge/Fog%3A%3ABrkt%20Version-alpha-green.svg)](https://github.com/brkt/fog-brkt-ruby)
 
 The following folder contains a collection of examples of using the Fog::Brkt module in Ruby scripts. Use these examples as your guide to integrate Fog::Ruby into your Bracket projects! For  description of the module please see: https://github.com/brkt/fog-brkt-ruby 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,14 @@
 
 [![Fog::Brkt VERSION](https://img.shields.io/badge/Fog%3A%3ABrkt%20Version-alpha-green.svg)](https://github.com/brkt/fog-brkt-ruby)
 
+![fog](http://geemus.s3.amazonaws.com/fog.png)
+
+fog is the Ruby cloud services library, top to bottom:
+
+* Collections provide a simplified interface, making clouds easier to work with and switch between.
+* Requests allow power users to get the most out of the features of each individual cloud.
+* Mocks make testing and integrating a breeze.
+
 The following folder contains a collection of examples of using the Fog::Brkt module in Ruby scripts. Use these examples as your guide to integrate Fog::Ruby into your Bracket projects! For  description of the module please see: https://github.com/brkt/fog-brkt-ruby 
 
 Note: All examples require a proper Bracket portal url, along with a proper API Token and Private Key. You will need to edit the following code block in each of these examples, and add in user specific data.

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ These Ruby files all have the .rb file extension. To run any of these Ruby scrip
 
 Alternatively, these example scripts have been configured to run without using the Ruby command. The shebang line is already done for you; it's the first line in the script starting with #!. This tells the shell what type of file this is. In this case it's a Ruby file to be executed with the Ruby interpreter. To mark the file as executable, run the command chmod +x {scriptname}.rb. This will set a file permission bit indicating that the file is a program and that it can be run. Now, to run the program simply enter the command ./{scriptname}.rb.
 
-<b>Since it's a bad practice to have your credentials in source code, you should load them from the default fog configuration file: ~/.fog. This file could look like this:</b>
+**Since it's a bad practice to have your credentials in source code, you should load them from the default fog configuration file: ~/.fog. This file could look like this:**
 
 ```
 default:
@@ -30,7 +30,7 @@ If there is no .fog file in your home directory, simply create one. For more inf
 
 Note: All examples require a proper Bracket portal url. You will need to edit the following code block in each of these examples, and add in the proper url of your portal.
 
-```
+```ruby
 # First establish a connection to the API portal
 ##########################################################
 compute = Fog::Compute.new({
@@ -40,7 +40,7 @@ compute = Fog::Compute.new({
 ##########################################################
 
 ```
-As an alternative, you could add the ```brkt_api_host:``` line to the .fog file shown above.
+As an alternative, you could add the `brkt_api_host:` line to the .fog file shown above.
 
 
 ## Contributing

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,15 +12,27 @@ fog is the Ruby cloud services library, top to bottom:
 
 The following folder contains a collection of examples of using the Fog::Brkt module in Ruby scripts. Use these examples as your guide to integrate Fog::Ruby into your Bracket projects! For  description of the module please see: https://github.com/brkt/fog-brkt-ruby 
 
-Note: All examples require a proper Bracket portal url, along with a proper API Token and Private Key. You will need to edit the following code block in each of these examples, and add in user specific data.
+## Usage
+
+These Ruby files all have the .rb file extension. To run any of these Ruby script, run the command ruby {scriptname}.rb. 
+
+Alternatively, these example scripts have been configured to run without using the Ruby command. The shebang line is already done for you; it's the first line in the script starting with #!. This tells the shell what type of file this is. In this case it's a Ruby file to be executed with the Ruby interpreter. To mark the file as executable, run the command chmod +x {scriptname}.rb. This will set a file permission bit indicating that the file is a program and that it can be run. Now, to run the program simply enter the command ./{scriptname}.rb.
+
+Since it's a bad practice to have your credentials in source code, you should load them from the default fog configuration file: ~/.fog. This file could look like this:
+
+default:
+  brkt_public_access_token: <YOUR_ACCESS_TOKEN>
+  brkt_private_mac_key: <YOUR_SECRET_MAC_KEY>
+
+If there is no .fog file in your home directory, simply create one.
+
+Note: All examples require a proper Bracket portal url. You will need to edit the following code block in each of these examples, and add in the proper url of your portal.
 
 ```
 # First establish a connection to the API portal
 ##########################################################
 compute = Fog::Compute.new({
     :provider => "brkt",
-    :brkt_public_access_token => "93e...",
-    :brkt_private_mac_key => "b48...",
     :brkt_api_host => "https://{url of portal @ brkt.com}/"
 })
 ##########################################################

--- a/examples/list-billing-groups.rb
+++ b/examples/list-billing-groups.rb
@@ -29,8 +29,6 @@ require "fog/brkt"
 ##########################################################
 compute = Fog::Compute.new({
     :provider => "brkt",
-    :brkt_public_access_token => "93e...",
-    :brkt_private_mac_key => "b48...",
     :brkt_api_host => "https://{url of portal @ brkt.com}/"
 })
 ##########################################################

--- a/examples/list-cells.rb
+++ b/examples/list-cells.rb
@@ -29,7 +29,7 @@ require "fog/brkt"
 ##########################################################
 compute = Fog::Compute.new({
     :provider => "brkt",
-    :brkt_api_host => "https://portal.stage.brkt.com/"
+    :brkt_api_host => "https://{url of portal @ brkt.com}/"
 })
 ##########################################################
 

--- a/examples/list-cells.rb
+++ b/examples/list-cells.rb
@@ -29,9 +29,7 @@ require "fog/brkt"
 ##########################################################
 compute = Fog::Compute.new({
     :provider => "brkt",
-    :brkt_public_access_token => "93e...",
-    :brkt_private_mac_key => "b48...",
-    :brkt_api_host => "https://{url of portal @ brkt.com}/"
+    :brkt_api_host => "https://portal.stage.brkt.com/"
 })
 ##########################################################
 

--- a/examples/list-running-workloads.rb
+++ b/examples/list-running-workloads.rb
@@ -29,8 +29,6 @@ require "fog/brkt"
 ##########################################################
 compute = Fog::Compute.new({
     :provider => "brkt",
-    :brkt_public_access_token => "93e...",
-    :brkt_private_mac_key => "b48...",
     :brkt_api_host => "https://{url of portal @ brkt.com}/"
 })
 ##########################################################

--- a/examples/list-workload-templates.rb
+++ b/examples/list-workload-templates.rb
@@ -29,8 +29,6 @@ require "fog/brkt"
 ##########################################################
 compute = Fog::Compute.new({
     :provider => "brkt",
-    :brkt_public_access_token => "93e...",
-    :brkt_private_mac_key => "b48...",
     :brkt_api_host => "https://{url of portal @ brkt.com}/"
 })
 ##########################################################


### PR DESCRIPTION
Since it's a bad practice to have your credentials in source code, you should load them from the default fog configuration file: ~/.fog. I Removed that section from the scripts and posted usage instructions in readme file.