### PR TITLE
Added the metadata attribute to the workload model

### DIFF
--- a/lib/fog/brkt/models/compute/workload.rb
+++ b/lib/fog/brkt/models/compute/workload.rb
@@ -32,6 +32,7 @@ module Fog
         attribute :service_domain
         attribute :expired
         attribute :workload_template
+        attribute :metadata
 
         # @!endgroup
 


### PR DESCRIPTION
I Added the metadata attribute to the workload model in order to
support pulling out the metadata tags from the workload. It was missing
for some reason