### PR TITLE
Pretty format and show errors for response validation

### DIFF
--- a/spec/support/matchers/format.rb
+++ b/spec/support/matchers/format.rb
@@ -21,8 +21,74 @@ end
 [Hash, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Hash) }
 [Array, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Array) }
 
+# Copied from fog-core and modified to provide more
+# detailed errors messages
+class DataValidator
+  attr_reader :errors
+
+  def initialize
+    @errors = []
+  end
+
+  def validate(data, schema, options = {})
+    validate_value(schema, data, options)
+  end
+
+  private
+
+  def validate_value(validator, value, options)
+    case validator
+    when Array
+      return false if value.is_a?(Hash)
+      value.respond_to?(:all?) && value.all? { |x| validate_value(validator[0], x, options) }
+    when Symbol
+      value.respond_to? validator
+    when Hash
+      if value.is_a?(Array)
+        add_error("expected '#{value}' to be Hash")
+        return false
+      end
+
+      # When being strict values not specified in the schema are fails
+      # Validator is empty but values are not
+      return false if !options[:allow_extra_keys] &&
+                      value.respond_to?(:empty?) &&
+                      !value.empty? &&
+                      validator.empty?
+
+      # Validator has rules left but no more values
+      return false if !options[:allow_optional_rules] &&
+                      value.respond_to?(:empty?) &&
+                      value.empty? &&
+                      !validator.empty?
+
+      validator.all? do |key, sub_validator|
+        result = validate_value(sub_validator, value[key], options)
+        unless result
+          add_error("'#{key}' has wrong format: expected #{sub_validator}, got #{value[key].inspect}")
+        end
+        result
+      end
+    else
+      result = validator == value
+      result = validator === value unless result
+      # Repeat unless we have a Boolean already
+      unless result.is_a?(TrueClass) || result.is_a?(FalseClass)
+        result = validate_value(result, value, options)
+      end
+      result
+    end
+  end
+
+  private
+
+  def add_error(error)
+    errors << error
+  end
+end
+
 RSpec::Matchers.define :have_format do |format|
-  validator = Fog::Schema::DataValidator.new
+  validator = DataValidator.new
 
   match do |data|
     options = { :allow_extra_keys => false, :allow_optional_rules => true }
@@ -31,11 +97,36 @@ RSpec::Matchers.define :have_format do |format|
 
   # Optional failure messages
   failure_message do |actual|
-    "expected #{actual.inspect} to have format #{format.inspect}"
+    message = <<-ERROR
+expected
+#{prettyfy(actual)}
+to have format
+#{prettyfy(format)}
+    ERROR
+
+    if validator.errors.any?
+      message += "\nErrors:\n" + validator.errors.join("\n")
+    end
   end
 
   # Optional method description
   description do
     "checks data gainst given format"
+  end
+
+  def prettyfy(hash)
+    longest_key_length = hash.inject(0) do |memo, (key, value)|
+      memo = key.length if key.length > memo
+      memo
+    end
+
+    sorted_hash = hash.sort { |(keyA, valA), (keyB, valB)| keyA <=> keyB }
+
+    "{\n" +
+    sorted_hash.map do |key, value|
+      key_with_padding = sprintf("%-#{longest_key_length}s", key)
+      "\t#{key_with_padding} => #{value.inspect}"
+    end.join(",\n") +
+    "\n}"
   end
 end


### PR DESCRIPTION
Error message example:

```
     Failure/Error: it { is_expected.to have_format(workload_format) }
       expected
       {
       	_links              => {"self"=>{"uri"=>"/v2/api/config/workload/b591fd3ea1348fd0"}},
       	billing_group       => "78f40ab9ce37886c",
       	created_by          => "user@brkt.com",
       	created_time        => "2014-05-20T19:56:58.782760+00:00",
       	customer            => "2b86ea2c4637408389c8aee9269d7b10",
       	deleted             => false,
       	description         => nil,
       	expired             => false,
       	id                  => "b591fd3ea1348fd0",
       	instances           => "/v1/api/config/workload/b591fd3ea1348fd0/instances",
       	lease_expire_time   => "2014-05-20T19:56:58.782760+00:00",
       	lease_modified_time => "2014-05-20T19:56:58.782760+00:00",
       	max_cost            => "1000.00",
       	modified_by         => "user@brkt.com",
       	modified_time       => "2014-05-20T19:56:58.782760+00:00",
       	name                => "fog-test-6a5af",
       	service_domain      => "example-workload",
       	state               => "INITIALIZING",
       	workload_template   => "eb9da135292646608e238aa043e90081",
       	zone                => "df43995a1d8a48d28b835238bfd079b4"
       }
       to have format
       {
       	billing_group       => String,
       	created_by          => String,
       	created_time        => String,
       	customer            => String,
       	deleted             => Fog::Boolean,
       	description         => Fog::Nullable::String,
       	expired             => Fog::Boolean,
       	id                  => String,
       	instances           => String,
       	lease_expire_time   => Fog::Nullable::String,
       	lease_modified_time => String,
       	max_cost            => Fog::Nullable::String,
       	metadata            => Hash,
       	modified_by         => String,
       	modified_time       => String,
       	name                => String,
       	service_domain      => Fog::Nullable::String,
       	state               => String,
       	workload_template   => Fog::Nullable::String,
       	zone                => String
       }
       
       Errors:
       'metadata' has wrong format: expected Hash, got nil
```