### PR TITLE
Get list of free volume attachment points for server

### DIFF
--- a/lib/fog/brkt/compute.rb
+++ b/lib/fog/brkt/compute.rb
@@ -146,6 +146,7 @@ module Fog
       request :update_cloudinit
       request :get_cloudinit
       request :list_cloudinits
+      request :get_server_free_volume_attach_points
 
       class Real
         # @return [String] api host

--- a/lib/fog/brkt/models/compute/server.rb
+++ b/lib/fog/brkt/models/compute/server.rb
@@ -255,6 +255,14 @@ module Fog
           false
         end
 
+        # Returns available volume attach points
+        #
+        # @return [Array]
+        def free_volume_attach_points
+          requires :id
+          service.get_server_free_volume_attach_points(id).body['free_brkt_volume_attach_points']
+        end
+
         private
 
         def ssh_options

--- a/lib/fog/brkt/requests/compute/get_server_free_volume_attach_points.rb
+++ b/lib/fog/brkt/requests/compute/get_server_free_volume_attach_points.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Compute
+    class Brkt
+      class Real
+        def get_server_free_volume_attach_points(server_id)
+          request(
+            :expects => [200],
+            :path    => "v1/api/config/instance/#{server_id}/freebrktvolumeattachpoint"
+          )
+        end
+      end
+
+      class Mock
+        def get_server_free_volume_attach_points(server_id)
+          response = {
+            "customer"                       => "ffffffffffff4fffafffffffffffff00",
+            "free_brkt_volume_attach_points" => ["/dev/xvdp", "/dev/xvdf", "/dev/xvdg", "/dev/xvdh", "/dev/xvdi", "/dev/xvdj", "/dev/xvdk", "/dev/xvdl", "/dev/xvdm", "/dev/xvdn", "/dev/xvdo"],
+            "modified_by"                    => "admin@brkt.com",
+            "description"                    => "",
+            "created_time"                   => "2015-10-23T08:35:00.819177+00:00",
+            "modified_time"                  => "2015-10-23T08:40:09.351525+00:00",
+            "id"                             => server_id,
+            "created_by"                     => "admin@brkt.com",
+            "name"                           => "vm-a2075cc9-0d1a-46ac-b40c-f3f0f79bb9c3"
+          }
+          Excon::Response.new(:body => response)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/compute/server_spec.rb
+++ b/spec/requests/compute/server_spec.rb
@@ -155,4 +155,38 @@ describe "server requests" do
       end
     end
   end
+
+  describe "#get_server_free_volume_attach_points" do
+    before(:all) do
+      @server = compute.servers.create(
+        :name            => Fog::Brkt::Mock.name,
+        :image_id        => image.id,
+        :machine_type_id => machine_type.id,
+        :workload        => @workload.id
+      )
+    end
+
+    after(:all) { @server.destroy }
+
+    describe "response" do
+      let(:response_format) do
+        {
+          "name"                           => String,
+          "customer"                       => String,
+          "free_brkt_volume_attach_points" => Array,
+          "modified_by"                    => String,
+          "description"                    => String,
+          "created_time"                   => String,
+          "modified_time"                  => String,
+          "id"                             => String,
+          "created_by"                     => String
+        }
+      end
+
+      subject { compute.get_server_free_volume_attach_points(@server.id).body }
+
+      it { is_expected.to have_format(response_format) }
+      it { expect(subject['id']).to eq @server.id      }
+    end
+  end
 end


### PR DESCRIPTION
Usage:

```ruby
s = compute.servers.get('someid')
s.free_volume_attach_points # ["/dev/xvdf", "/dev/xvdg", "/dev/xvdh", "/dev/xvdi", "/dev/xvdj", "/dev/xvdk", "/dev/xvdl", "/dev/xvdm", "/dev/xvdn", "/dev/xvdo"]
```