### PR TITLE
Add net-ssh and net-scp as fog-brkt dependencies

### DIFF
--- a/fog-brkt.gemspec
+++ b/fog-brkt.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rspec", "~> 3.2"
 
+  spec.add_dependency "net-ssh", "~> 3.0.1"
+  spec.add_dependency "net-scp", "~> 1.2.1"
   spec.add_dependency "fog-core", "~> 1.29"
   spec.add_dependency "fog-xml", "~> 0.1"
   spec.add_dependency "fog-json", "~> 1.0"

--- a/lib/fog/brkt/models/compute/server.rb
+++ b/lib/fog/brkt/models/compute/server.rb
@@ -1,4 +1,5 @@
 require "fog/compute/models/server"
+require "net/ssh"
 
 module Fog
   module Compute
@@ -220,7 +221,9 @@ module Fog
         def upload(local_path, remote_path, upload_options = {})
           requires :ssh_ip_address, :ssh_username
 
-          Fog::SCP.new(ssh_ip_address, ssh_username, ssh_options).upload(local_path, remote_path, upload_options)
+          options = ssh_options.merge(upload_options)
+
+          Fog::SCP.new(ssh_ip_address, ssh_username, options).upload(local_path, remote_path)
         end
 
         # Download file from server using SCP
@@ -231,7 +234,9 @@ module Fog
         def download(remote_path, local_path, download_options = {})
           requires :ssh_ip_address, :ssh_username
 
-          Fog::SCP.new(ssh_ip_address, ssh_username, ssh_options).download(remote_path, local_path, download_options)
+          options = ssh_options.merge(download_options)
+
+          Fog::SCP.new(ssh_ip_address, ssh_username, options).download(remote_path, local_path)
         end
 
         # Run commands on server with SSH


### PR DESCRIPTION
This fixes Server#upload & Server#download methods. Fog-core gem does not have 'net-ssh' & 'net-scp' as dependencies.